### PR TITLE
Initial commit of manual OCR node toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+manual_ocr_toolchain/node_modules

--- a/manual_ocr_toolchain/package-lock.json
+++ b/manual_ocr_toolchain/package-lock.json
@@ -1,0 +1,20 @@
+{
+  "name": "scattered_path",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "dev": true
+    }
+  }
+}

--- a/manual_ocr_toolchain/package.json
+++ b/manual_ocr_toolchain/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "scattered_path",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "npm run format && node src/main.js",
+    "format": "prettier --write 'src/**/*.js'"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {},
+  "devDependencies": {
+    "pngjs": "^5.0.0",
+    "prettier": "^2.0.5"
+  }
+}

--- a/manual_ocr_toolchain/src/compileText.js
+++ b/manual_ocr_toolchain/src/compileText.js
@@ -1,0 +1,122 @@
+const fs = require("fs");
+
+const characterMapping = {
+  " ": " ",
+  "-": "-",
+  ".": ".",
+  "!": "!",
+  "00": "e",
+  "01": "t",
+  "02": "a",
+  "03": "r",
+  "04": "i",
+  "05": "o",
+  "06": "n",
+  "07": "s",
+  "08": "h",
+  "09": "d",
+  "10": "l",
+  "11": "u",
+  "12": "w",
+  "13": "m",
+  "14": "f",
+  "15": "c",
+  "16": "g",
+  "17": "y",
+  "18a": "p",
+  "18b": "",
+  "19": "b",
+  "20": "k",
+  "21": "v",
+};
+
+const sortedGlyphsPath = "./sorted_glyphs";
+
+const compileText = async () => {
+  const characters = fs
+    .readdirSync(sortedGlyphsPath)
+    .filter((fileName) => fileName.startsWith("_"))
+    .map((fileName) => [fileName, `${sortedGlyphsPath}/${fileName}`])
+    .filter(([_, path]) => fs.lstatSync(path).isDirectory())
+    .map(([folderName, path]) =>
+      fs
+        .readdirSync(path)
+        .filter((fileName) => fileName.endsWith(".png"))
+        .map((fileName) => {
+          const [
+            pageIndex,
+            columnIndex,
+            lineIndex,
+            charIndex,
+          ] = fileName.replace(".png", "").split("_");
+          const char = characterMapping[folderName.replace("_", "")];
+          const lineID = `${pageIndex}_${columnIndex}_${lineIndex}`;
+          return {
+            lineID,
+            charIndex: parseInt(charIndex),
+            char,
+          };
+        })
+    )
+    .flat();
+
+  const allLineIDs = Array.from(
+    new Set(characters.map(({ lineID }) => lineID))
+  ).sort();
+
+  const lines = allLineIDs.map((lineID) => {
+    const [pageIndex, columnIndex, lineIndex] = lineID.split("_");
+    return {
+      pageIndex,
+      columnIndex,
+      lineIndex,
+      text: characters
+        .filter((char) => lineID === char.lineID)
+        .sort((p, q) => p.charIndex - q.charIndex)
+        .map(({ char }) => char)
+        .join(""),
+    };
+  });
+
+  const clumps = lines.reduce((clumpsSoFar, line) => {
+    const { pageIndex, columnIndex, lineIndex } = line;
+
+    const lastClump = clumpsSoFar[clumpsSoFar.length - 1];
+    let appendLastClump = false;
+    if (
+      lastClump != null &&
+      lastClump.pageIndex === pageIndex &&
+      lastClump.columnIndex === columnIndex
+    ) {
+      const lastLineIndex =
+        lastClump.lines[lastClump.lines.length - 1].lineIndex;
+      if (lineIndex - lastLineIndex === 2) {
+        appendLastClump = true;
+      }
+    }
+
+    if (appendLastClump) {
+      lastClump.lines.push(line);
+    } else {
+      clumpsSoFar.push({
+        pageIndex,
+        columnIndex,
+        lineIndex,
+        lines: [line],
+      });
+    }
+
+    return clumpsSoFar;
+  }, []);
+
+  const wholeText = clumps.map((clump) => printClump(clump)).join("\n\n");
+  fs.writeFileSync(`./compiled_text.txt`, wholeText);
+};
+
+const printClump = ({ pageIndex, columnIndex, lineIndex, lines }) =>
+  [
+    `page ${pageIndex} column ${columnIndex} line ${lineIndex}:`,
+    ...lines.map(({ text }) => text),
+  ].join("\n\t");
+
+module.exports = { compileText };

--- a/manual_ocr_toolchain/src/generateGlyphs.js
+++ b/manual_ocr_toolchain/src/generateGlyphs.js
@@ -1,0 +1,155 @@
+const fs = require("fs");
+const PNG = require("pngjs").PNG;
+
+const linesPath = "./lines";
+const glyphsPath = "./glyphs";
+
+const loadLinePNG = (fileName) =>
+  new Promise((resolve) =>
+    fs
+      .createReadStream(`${linesPath}/${fileName}`)
+      .pipe(new PNG({ filterType: 4 }))
+      .on("parsed", function () {
+        resolve(this);
+      })
+  );
+
+const saveGlyphPNG = (fileName, index, data) =>
+  new Promise((resolve) => {
+    fileName = fileName.replace(".png", `_${index}.png`);
+    const height = data[0].length;
+    const width = data.length;
+    const png = new PNG({ filterType: 4, width, height });
+    const rotatedData = Array(height)
+      .fill()
+      .map((_, y) =>
+        Array(width)
+          .fill()
+          .map((_, x) => Math.floor(data[x][height - y - 1]))
+      );
+    // console.log(printStrips(rotatedData));
+    // return;
+    png.data = Buffer.from(
+      rotatedData
+        .flat()
+        .map((value) => [value, value, value, 0xff])
+        .flat()
+    );
+    png
+      .pack()
+      .pipe(fs.createWriteStream(`${glyphsPath}/${fileName}`))
+      .on("finish", function () {
+        resolve();
+      });
+  });
+
+const printStrips = (strips, displayThreshold = 0x88) =>
+  [
+    Array(strips[0].length * 3 + 2)
+      .fill("-")
+      .join(""),
+    ...strips.map(
+      (strip) =>
+        "|" +
+        strip
+          .map((value) =>
+            value > displayThreshold
+              ? "   "
+              : value.toString(16).padStart(2, "0") + " "
+          )
+          .join("") +
+        "|"
+    ),
+    Array(strips[0].length * 3 + 2)
+      .fill("-")
+      .join(""),
+  ].join("\n");
+
+const processLine = async (fileName, png) => {
+  const { width, height, data } = png;
+
+  const greenPixelValues = Array(data.length / 4)
+    .fill()
+    .map((_, index) =>
+      Math.min(data[index * 4 + 0], data[index * 4 + 1], data[index * 4 + 2])
+    );
+
+  const valueThreshold = 0x70;
+  const coverageThreshold = 2;
+
+  const allStrips = Array(width)
+    .fill()
+    .map((_, x) =>
+      Array(height)
+        .fill()
+        .map((_, y) => greenPixelValues[(height - y - 1) * width + x])
+    );
+
+  const spaceStrip = Array(15).fill(0xff);
+
+  const glyphs = allStrips
+    .reduce((glyphsSoFar, strip) => {
+      const isStripEmpty =
+        strip.filter((value) => value < valueThreshold).length <
+        coverageThreshold;
+      if (isStripEmpty) {
+        strip = spaceStrip;
+      }
+      let latestGlyph = glyphsSoFar[glyphsSoFar.length - 1];
+      if (
+        isStripEmpty !== (latestGlyph != null && latestGlyph[0] === spaceStrip)
+      ) {
+        latestGlyph = [];
+        glyphsSoFar.push(latestGlyph);
+      }
+      latestGlyph.push(strip);
+      return glyphsSoFar;
+    }, [])
+    .filter(
+      (glyph, index, { length }) =>
+        glyph[0] !== spaceStrip ||
+        (glyph.length > 10 && index > 0 && index < length - 1)
+    )
+    .filter((glyph) => glyph[0].length >= 5 && glyph.length >= 5)
+    .map((glyph) => {
+      if (glyph[0] === spaceStrip) {
+        return Array(5).fill(spaceStrip);
+      }
+      const min = Math.min(
+        ...glyph.map((strip) =>
+          strip.findIndex((value) => value <= valueThreshold)
+        )
+      );
+      const max = Math.max(
+        ...glyph.map(
+          (strip) =>
+            strip.length -
+            strip
+              .slice()
+              .reverse()
+              .findIndex((value) => value <= valueThreshold)
+        )
+      );
+      return glyph.map((strip) => strip.slice(min, max));
+    });
+
+  await Promise.all(
+    glyphs.map((glyph, index) => saveGlyphPNG(fileName, index, glyph))
+  );
+};
+
+const generateGlyphs = async () => {
+  const imageNames = fs
+    .readdirSync(linesPath)
+    .filter((name) => name.endsWith(".png"));
+
+  const images = await Promise.all(
+    imageNames
+      // .slice(0, 1)
+      .map((fileName) =>
+        loadLinePNG(fileName).then((png) => processLine(fileName, png))
+      )
+  );
+};
+
+module.exports = { generateGlyphs };

--- a/manual_ocr_toolchain/src/main.js
+++ b/manual_ocr_toolchain/src/main.js
@@ -1,0 +1,5 @@
+const { generateGlyphs } = require("./generateGlyphs.js");
+const { compileText } = require("./compileText.js");
+
+// generateGlyphs();
+compileText();


### PR DESCRIPTION
This node project contains scripts I used to automate parts of my mostly manual OCR process:

1. I scanned the booklet into a one-page-per-layer Photoshop document
1. I set these layers' fills to 30%, manually lined up their lines of text, and set guides to isolate each line.
1. I replaced each dropcap glyph with a smaller glyph of the same shape.
1. I generated image slices from the guides, and exported all the lines into a folder of PNGs, with names like `02_a_55.png` signifying "page 2, column A, line 55".
1. I wrote a node script, `generateGlyphs.js`, which took each line PNG, tried to break them into pieces based on letter and word separation, and then cropped those pieces, which were saved back out to a folder of PNGs, with names like `02_a_55_0.png` signifying "page 2, column A, line 55, glyph 0". This script has trouble with identifying spaces, which can be different sizes in different lines of text, and are sometimes smaller than the space between the two halves of the `EZ`-shaped glyph.
1. I manually sorted the folder of 17,744 glyph PNGs into subfolders, with names like `_04` signifying "glyph of shape 4". This was partly aided by sorting the glyph directory's contents by width, height and file size. In hindsight, I should have added more information to the file names from the previous step, signifying some basic topological properties of each image, like the number of separate regions of dark pixels. I also maintained a folder named `_!` of errata to fix later. The two halves of the `EZ`-shaped glyph went into `_18a` and `_18b`.
1. I wrote another node script, `compileText.js`, which took the sorted glyphs directory, identified its folder contents and their folder contents (ie. the sorted glyph PNGs), used the folder and file names to recombine the line text, and then clumped the lines together into contiguous text regions, or "clumps".
1. I grabbed one of each glyph PNG and traced them in Illustrator with an angled blob brush. I exported these vector glyphs as SVG, dropped them into [http://icomoon.io](IcoMoon) and downloaded a TTF font.
1. In Photoshop, I made numbered, cropped, red-tinted versions of the text pages and saved them out as separate PNGs.
1. In InDesign, I made a document where each page contained one red-tinted text page PNG. I then pasted the text clumps into text boxes, which I positioned over the images and adjusted. This process helped to establish word boundaries missed by the glyph generator, and helped identify a couple other OCR-related mistakes.
1. I extracted the text from the InDesign document, verified that the hyphens in the text were purely for line-breaking purposes and not to convey information, and joined the text clumps into paragraph strings. I annotated this document with page numbers, column dividers, drop-cap indicators and written descriptions of the images, so that people who don't have a PDF or physical copy of the booklet can glean as much information from the file as possible.

As you can see, this was a mostly manual (and at times very labor-intensive) process, which contained definite sources of error as well as steps taken to error-check. While we can improve this methodology, our best way of error-checking is to ask Jason Roberts to compare the output to his text document, assuming he still has it. Our next best way of error-checking is to rely on statistical analysis to identify and address outliers in the text.